### PR TITLE
Enable CORS for order webhook

### DIFF
--- a/order/order.js
+++ b/order/order.js
@@ -22,7 +22,7 @@
     style: "currency", currency: (MENU && MENU.currency) || "CAD"
   }).format(isFinite(n) ? n : 0);
 
-  function postOrderWebhook(payload) {
+  async function postOrderWebhook(payload) {
     const url = CFG?.hooks?.ordersWebhook;
     if (!url) return;
 
@@ -39,11 +39,10 @@
 
     // Fallback: fetch keepalive (<=64KB body)
     try {
-      fetch(url, {
+      await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: json,
-        mode: "no-cors",
         keepalive: true
       });
     } catch (err) {
@@ -617,7 +616,7 @@
       taxRate: state.taxRate, taxName: CFG.taxName || "HST", currency: (MENU && MENU.currency) || "CAD"
     };
 
-    postOrderWebhook(payload);
+    await postOrderWebhook(payload);
 
     const ticket = kitchenTicket(payload);
 

--- a/order/ordersWebhook.gs
+++ b/order/ordersWebhook.gs
@@ -1,0 +1,13 @@
+// Google Apps Script for order webhook
+/**
+ * Receives order payload and responds with permissive CORS headers.
+ * @param {GoogleAppsScript.Events.DoPost} e
+ */
+function doPost(e) {
+  const data = JSON.parse(e.postData.contents || '{}');
+  // TODO: handle the order data, e.g., store in a sheet or send notifications
+  const output = ContentService.createTextOutput(JSON.stringify({ status: 'ok' }))
+    .setMimeType(ContentService.MimeType.JSON)
+    .setHeader('Access-Control-Allow-Origin', '*');
+  return output;
+}


### PR DESCRIPTION
## Summary
- allow CORS by removing `no-cors` and awaiting webhook fetch
- document Google Apps Script endpoint with CORS headers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ebb67d8c08322a6caa060e3afaa75